### PR TITLE
Build prod_* images directly, remove promote workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=test_{{date 'YYYY-MM-DD_HHmmss'}},enable={{is_default_branch}}
+            type=raw,value=prod_{{date 'YYYY-MM-DD_HHmmss'}},enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/Removed/promote.yaml
+++ b/Removed/promote.yaml
@@ -1,0 +1,151 @@
+name: Promote and Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action to perform"
+        required: true
+        type: choice
+        options:
+          - promote
+          - rollback-test
+          - rollback-int
+          - rollback-prod
+        default: promote
+      source_tag:
+        description: "Source image tag (e.g., test_2026-02-15_143022)"
+        required: true
+        type: string
+
+jobs:
+  # Promote to INT (retag source image as int_*, no rebuild)
+  move-to-int:
+    if: github.ref == 'refs/heads/main' && inputs.action == 'promote'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create INT tag
+        id: docker_tag
+        run: echo "tag=int_$(date '+%Y-%m-%d_%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Retag image for INT
+        run: |
+          echo "Promoting ${{ inputs.source_tag }} to ${{ steps.docker_tag.outputs.tag }}"
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.docker_tag.outputs.tag }} \
+            ghcr.io/${{ github.repository }}:${{ inputs.source_tag }}
+
+  # Promote to PROD (retag source image as prod_*, no rebuild)
+  move-to-prod:
+    if: github.ref == 'refs/heads/main' && inputs.action == 'promote'
+    needs: move-to-int
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PROD tag
+        id: docker_tag
+        run: echo "tag=prod_$(date '+%Y-%m-%d_%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Retag image for PROD
+        run: |
+          echo "Promoting ${{ inputs.source_tag }} to ${{ steps.docker_tag.outputs.tag }}"
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.docker_tag.outputs.tag }} \
+            ghcr.io/${{ github.repository }}:${{ inputs.source_tag }}
+
+  # Rollback TEST to a previous image
+  rollback-test:
+    if: github.ref == 'refs/heads/main' && inputs.action == 'rollback-test'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create TEST rollback tag
+        id: docker_tag
+        run: echo "tag=test_$(date '+%Y-%m-%d_%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Retag image for TEST
+        run: |
+          echo "Rolling back TEST to ${{ inputs.source_tag }} as ${{ steps.docker_tag.outputs.tag }}"
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.docker_tag.outputs.tag }} \
+            ghcr.io/${{ github.repository }}:${{ inputs.source_tag }}
+
+  # Rollback INT to a previous image
+  rollback-int:
+    if: github.ref == 'refs/heads/main' && inputs.action == 'rollback-int'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create INT rollback tag
+        id: docker_tag
+        run: echo "tag=int_$(date '+%Y-%m-%d_%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Retag image for INT
+        run: |
+          echo "Rolling back INT to ${{ inputs.source_tag }} as ${{ steps.docker_tag.outputs.tag }}"
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.docker_tag.outputs.tag }} \
+            ghcr.io/${{ github.repository }}:${{ inputs.source_tag }}
+
+  # Rollback PROD to a previous image
+  rollback-prod:
+    if: github.ref == 'refs/heads/main' && inputs.action == 'rollback-prod'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create PROD rollback tag
+        id: docker_tag
+        run: echo "tag=prod_$(date '+%Y-%m-%d_%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Retag image for PROD
+        run: |
+          echo "Rolling back PROD to ${{ inputs.source_tag }} as ${{ steps.docker_tag.outputs.tag }}"
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}:${{ steps.docker_tag.outputs.tag }} \
+            ghcr.io/${{ github.repository }}:${{ inputs.source_tag }}


### PR DESCRIPTION
This service has a single deployment environment. Changed CI tag format from \`test_YYYY-MM-DD_HHmmss\` to \`prod_YYYY-MM-DD_HHmmss\` so Flux picks up new builds automatically without a manual promotion step.

The \`promote.yaml\` workflow is no longer needed and has been moved to \`Removed/\`.

The Flux ImagePolicy in gitops-main was already updated to watch \`prod_*\` tags.