### PR TITLE
Change Docker build tags from test_* to prod_*

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=test_{{date 'YYYY-MM-DD_HHmmss'}},enable={{is_default_branch}}
+            type=raw,value=prod_{{date 'YYYY-MM-DD_HHmmss'}},enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 ---
 
+## March 2026
+
+### 2026-03-02
+
+**Change Docker build tags from test_* to prod_* for production**
+- Since cube-validator only has a production environment, the main branch build now produces `prod_*` tags directly
+- Changed `test_YYYY-MM-DD_HHmmss` to `prod_YYYY-MM-DD_HHmmss` in `.github/workflows/docker.yml`
+- This allows Flux to pick up new images automatically without needing the promote workflow
+
+---
+
 ## February 2026
 
 ### 2026-02-17
@@ -169,4 +180,4 @@
 
 ---
 
-*Last updated: 2025-12-17*
+*Last updated: 2026-03-02*


### PR DESCRIPTION
Since cube-validator only has a production environment, the main branch build should produce prod_* tags directly instead of test_*. This allows Flux to pick up new images automatically without needing the promote workflow.